### PR TITLE
Fix dictionary order dependent behavior

### DIFF
--- a/few_shot_learning_system.py
+++ b/few_shot_learning_system.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import os
 
 import numpy as np
@@ -99,7 +100,7 @@ class MAMLFewShotClassifier(nn.Module):
         :param params: A dictionary of the network's parameters.
         :return: A dictionary of the parameters to use for the inner loop optimization process.
         """
-        param_dict = dict()
+        param_dict = OrderedDict()
         for name, param in params:
             if param.requires_grad:
                 if self.args.enable_inner_loop_optimizable_bn_params:
@@ -130,7 +131,7 @@ class MAMLFewShotClassifier(nn.Module):
                                                            grads.to(device=self.device)),
             names_weights_copy.values(), self.task_learning_rate[current_step_idx], grads))
 
-        names_weights_copy = dict(zip(names_weights_copy.keys(), updated_weights))
+        names_weights_copy = OrderedDict(zip(names_weights_copy.keys(), updated_weights))
 
         return names_weights_copy
 


### PR DESCRIPTION
Previous code was using dictionary to store current parameters (`names_weights`).
However, `apply_inner_loop_update` highly depends on the order of this dictionary key or value.
It would cause issue #9 or #11 because of the order mismatch between training time and test time.
So the dictionary is simply replaced with OrderedDict in order to preserve its key/value order.

issue: #9, #11